### PR TITLE
Improve sparse CSR support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.8", "3.9", "3.10" ]
-        torch-version: [ "torch-1.10", "torch-1.11" ]
+        torch-version: [ "torch-1.11" ]
         exclude:
           - python-version: "3.10"
             torch-version: "torch-1.10"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,7 +90,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     more_itertools
     # Use progress bars excessively
     tqdm
-    torch
+    torch>=1.11
     # for automatic batch size selection
     torch_max_mem
 

--- a/src/torch_ppr/utils.py
+++ b/src/torch_ppr/utils.py
@@ -129,7 +129,8 @@ def validate_adjacency(adj: torch.Tensor, n: Optional[int] = None):
         raise ValueError(f"Invalid adjacency matrix shape: {adj.shape}. expected: {(n, n)}")
 
     # check value range
-    adj = adj.coalesce()
+    if adj.is_sparse and not adj.is_sparse_csr:
+        adj = adj.coalesce()
     values = adj.values()
     if (values < 0.0).any() or (values > 1.0).any():
         raise ValueError(
@@ -137,7 +138,11 @@ def validate_adjacency(adj: torch.Tensor, n: Optional[int] = None):
         )
 
     # check column-sum
-    adj_sum = torch.sparse.sum(adj, dim=0).to_dense()
+    if adj.is_sparse and not adj.is_sparse_csr:
+        adj_sum = torch.sparse.sum(adj, dim=0).to_dense()
+    else:
+        # hotfix until torch.sparse.sum is implemented
+        adj_sum = adj.t() @ torch.ones(adj.shape[0])
     if not torch.allclose(adj_sum, torch.ones_like(adj_sum)):
         raise ValueError(f"Invalid column sum: {adj_sum}. expected 1.0")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,6 +69,8 @@ class UtilsTest(unittest.TestCase):
         utils.validate_adjacency(adj=adj)
         # plain validation with explicit shape
         utils.validate_adjacency(adj=adj, n=self.num_nodes)
+        # validation with CSR matrix
+        utils.validate_adjacency(adj=adj.to_sparse_csr())
         # test error raising
         for adj in (
             # an edge_index instead of adj

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ envlist =
     docstr-coverage
     docs-test
     # the actual tests
-    py-torch-{1.10,1.11}
+    py-torch-{1.11}
     # always keep coverage-report last
     # coverage-report
 
@@ -37,7 +37,6 @@ commands =
 setenv = 
     PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 deps =
-    torch-1.10: torch~=1.10.0
     torch-1.11: torch~=1.11.0
 extras =
     # See the [options.extras_require] entry in setup.cfg for "tests"


### PR DESCRIPTION
At least on CPU, CSR matrices tend to be faster to multiply with a dense matrix.

Also sets the torch minimum version to 1.11